### PR TITLE
[doc] fix link of create-react-native-dapp

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This project is using:
 
-- [create-react-native-dapp](cawfree/create-react-native-dapp) to bootstrap the project.
+- [create-react-native-dapp](https://github.com/cawfree/create-react-native-dapp) to bootstrap the project.
 - [WalletConnect v1 react-native integration](https://docs.walletconnect.com/1.0/quick-start/dapps/react-native) for authenthication (we use a slightly modiefied version, located in `./src/WalletConnect` to allow to modify the `enable` function of Moralis).
 - [react-moralis](https://github.com/MoralisWeb3/react-moralis) for react hooks
 


### PR DESCRIPTION
the first link user can click is broken